### PR TITLE
Added MapStringStringToClassAd func and accompanying test cases

### DIFF
--- a/classad/classad.go
+++ b/classad/classad.go
@@ -115,6 +115,8 @@ func ReadClassAds(r io.Reader) ([]ClassAd, error) {
 }
 
 // MapStringStringToClassAd converts a map[string]string to a ClassAd.
+// It will attempt to convert values to numeric Types when appropriate. For example, a string value of "42"
+// will be converted to Attribute{Type: Integer, Value: 42}
 func MapStringStringToClassAd(m map[string]string) ClassAd {
 	ad := make(ClassAd)
 	for k, v := range m {

--- a/classad/classad.go
+++ b/classad/classad.go
@@ -114,6 +114,15 @@ func ReadClassAds(r io.Reader) ([]ClassAd, error) {
 	return ads, nil
 }
 
+// MapStringStringToClassAd converts a map[string]string to a ClassAd.
+func MapStringStringToClassAd(m map[string]string) ClassAd {
+	ad := make(ClassAd)
+	for k, v := range m {
+		ad[k] = AttributeFromString(v)
+	}
+	return ad
+}
+
 // StreamClassAds reads multiple ClassAds (in "long" format) from r
 // until EOF, writing them to the supplied channel, which is closed
 // when all are read or upon error.  ClassAds should be separated by a

--- a/classad/classad_test.go
+++ b/classad/classad_test.go
@@ -2,6 +2,7 @@ package classad
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -25,6 +26,52 @@ func TestReadClassAd_good(t *testing.T) {
 	}
 	for _, ad := range ads {
 		t.Log(ad.Strings())
+	}
+}
+
+func TestMapStringStringToClassAd(t *testing.T) {
+	type testCase struct {
+		description string
+		m           map[string]string
+		expected    ClassAd
+	}
+
+	testCases := []testCase{
+		{
+			"Good case",
+			map[string]string{
+				"Attr1": "Value1",
+				"Attr2": "2",
+				"Attr3": "3.4",
+			},
+			ClassAd{
+				"Attr1": Attribute{
+					Type:  String,
+					Value: "Value1",
+				},
+				"Attr2": Attribute{
+					Type:  Integer,
+					Value: int64(2),
+				},
+				"Attr3": Attribute{
+					Type:  Real,
+					Value: 3.4,
+				},
+			},
+		},
+		{
+			"Empty case",
+			make(map[string]string),
+			ClassAd{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			if result := MapStringStringToClassAd(tc.m); !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("expected %v classad, got %v", tc.expected, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This PR adds a function to the `classad` package, called `MapStringStringToClassAd`.  It simply takes a `map[string]string` and creates a `ClassAd` object from that.

I have added a test with two test cases as well.