### PR TITLE
Add Env field to Command struct

### DIFF
--- a/command.go
+++ b/command.go
@@ -71,6 +71,13 @@ type Command struct {
 	Attributes []string
 	// Args is a list of any extra arguments to pass.
 	Args []string
+	// Env is the environment the command will run in.
+	// Env is similar to exec.Cmd.Env, namely:
+	// - Each entry is of the form "key=value".
+	// - If Env is nil, the Command uses the current process's
+	// environment.
+	// - If Env contains duplicate key-value strings, the last will be used
+	Env []string
 	// cache is an optional groupcache pool to cache
 	// queries. Inititalize with WithCache().
 	cache         *groupcache.HTTPPool
@@ -96,6 +103,7 @@ func (c *Command) Copy() *Command {
 		Constraint:    c.Constraint,
 		Attributes:    make([]string, len(c.Attributes)),
 		Args:          make([]string, len(c.Args)),
+		Env:           make([]string, len(c.Env)),
 		cache:         c.cache,
 		cacheGroup:    c.cacheGroup,
 		cacheLifetime: c.cacheLifetime,
@@ -105,6 +113,9 @@ func (c *Command) Copy() *Command {
 	}
 	if len(c.Args) > 0 {
 		copy(cc.Args, c.Args)
+	}
+	if len(c.Env) > 0 {
+		copy(cc.Env, c.Env)
 	}
 	return &cc
 }
@@ -166,6 +177,12 @@ func (c *Command) WithArg(arg string) *Command {
 	return c
 }
 
+// WithEnv sets the environment in which the command will run.
+func (c *Command) WithEnv(env []string) *Command {
+	c.Env = env
+	return c
+}
+
 // MakeArgs builds the complete argument list to be passed to the command.
 func (c *Command) MakeArgs() []string {
 	args := make([]string, 0)
@@ -196,13 +213,17 @@ func (c *Command) MakeArgs() []string {
 // Cmd generates an exec.Cmd you can use to run the command manually.
 // Use Run() to run the command and get back ClassAds.
 func (c *Command) Cmd() *exec.Cmd {
-	return exec.Command(c.Command, c.MakeArgs()...)
+	cmd := exec.Command(c.Command, c.MakeArgs()...)
+	cmd.Env = c.Env
+	return cmd
 }
 
 // CmdContext generates an exec.Cmd with context you can use to run the command
 // manually. Use Run() to run the command and get back ClassAds.
 func (c *Command) CmdContext(ctx context.Context) *exec.Cmd {
-	return exec.CommandContext(ctx, c.Command, c.MakeArgs()...)
+	cmd := exec.CommandContext(ctx, c.Command, c.MakeArgs()...)
+	cmd.Env = c.Env
+	return cmd
 }
 
 // encodeKey encodes the command into a string, to be used as a cache key.

--- a/command_test.go
+++ b/command_test.go
@@ -1,6 +1,7 @@
 package htcondor
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/golang/groupcache"
@@ -201,4 +202,23 @@ func TestCondorHistoryAttribute(t *testing.T) {
 		t.Errorf("expected one ClassAd, got %d", len(ads))
 	}
 	t.Log(ads)
+}
+
+func TestCondorCommandWithEnv(t *testing.T) {
+	inputEnv := []string{"FOO=bar"}
+	c := NewCommand("condor_q").WithEnv(inputEnv)
+	if !slices.Equal(inputEnv, c.Env) {
+		t.Errorf("Did not get expected Env field. Expected %v, got %v", inputEnv, c.Env)
+	}
+}
+
+func TestCondorCommandEnv(t *testing.T) {
+	// Set environment up that we want to override in the invocation of NewCommand
+	t.Setenv("FOO", "bar")
+	c := NewCommand("condor_q").WithEnv([]string{"FOO=baz"}) // This should set FOO=baz in the Command.Env field
+	cmd := c.Cmd()
+	if !slices.Contains(cmd.Environ(), "FOO=baz") {
+		t.Error("expected environment variable setting \"FOO=baz\" to be set in Command.Env, but did not find it")
+	}
+	t.Log(cmd.Environ())
 }


### PR DESCRIPTION
## Summary

The `Env` field, like the stdlib's `exec.Cmd.Env`, is a slice of strings that denote key-value pairs (e.g. `[]string{"FOO=bar"}`). The `Env` is simply passed as-is to create the `exec.Cmd` object when a command is run, and if not-nil, becomes the environment that the `exec.Cmd` process runs in.  

We also add here a constructor method, `*Command.WithEnv`, that sets the `Command.Env` field, and modified the `*Command.Copy` method so it also copies an existing `Command`'s `Env` to the new one.

## Use case

Currently, it is possible to set an environment to run a `Command` in, and an example can be seen here:  
https://github.com/fnal-fife/jobsub-pnfs-dropbox-cleanup/blob/5168a5d0fc30284fa22350bcee42e55687f532eb/condorSchedd.go#L132

The code structure would be something like this, where the `classad.ClassAds` could only be gotten by parsing the `stdout` of the `Command.Cmd()`'s returned`exec.Cmd` (which is simply done with the `classad.ReadClassads` function):

```go
c := NewCommand("condor_q")
cmd := c.Cmd()
cmd.Env = []string{"FOO=bar"}

out, err := cmd.Output()
if err != nil {
// Handle Error
}

ads, err := classad.ReadClassads(bytes.NewReader(out))
if err != nil {
// Handle Error
}
```

However, this means that right now, a user would have to implement the functionality of `Command.Run()` themselves if they want to change a `Command`'s environment, and they would lose the caching advantages that `Run` provides by default.  With the change in this PR, the above code could reliably be reduced to:

```go
c := NewCommand("condor_q").WithEnv([]string{"FOO=bar"})
ads, err := c.Run()
if err != nil {
// Handle error
}
```